### PR TITLE
Use calculateMetadata() to fetch the durations

### DIFF
--- a/src/Bucket.tsx
+++ b/src/Bucket.tsx
@@ -1,14 +1,6 @@
-import {useGLTF} from '@react-three/drei';
-import {staticFile} from 'remotion';
-
-const modelSrc = staticFile('/3d-models/bucket.glb');
-
-export function Bucket({position}) {
-	const model = useGLTF(modelSrc);
-
-	if (!model) {
+export function Bucket(props: {position: any; model: any}) {
+	if (!props.model) {
 		return null;
 	}
-
-	return <primitive position={position} object={model.scene} />;
+	return <primitive position={props.position} object={props.model.scene} />;
 }

--- a/src/Phone.tsx
+++ b/src/Phone.tsx
@@ -173,34 +173,11 @@ export const Phone: React.FC<{
 
 export const LoopedVideoPhone = (props: any) => {
 	const {fps} = useVideoConfig();
-
-	const [videoDuration, setVideoDuration] = useState<number | undefined>(5);
-
-	// TODO: everything below is commented out because I have no idea why continueRender is not working
-	// const [videoDurationHandle] = useState(() => delayRender('videoDuration'));
-
-	// const getVideoDuration = useCallback(async () => {
-	// 	try {
-	// 		const metadata = await getVideoMetadata(props.videoSrc);
-
-	// 		setVideoDuration(metadata.durationInSeconds);
-	// 		continueRender(videoDurationHandle);
-	// 	} catch (error) {
-	// 		console.error(error);
-	// 		cancelRender(error);
-	// 	}
-	// }, []);
-
-	// useEffect(() => {
-	// 	getVideoDuration();
-	// }, [getVideoDuration]);
-
-	if (!videoDuration) {
-		return null;
-	}
-
 	return (
-		<Loop layout="none" durationInFrames={Math.floor(fps * videoDuration)}>
+		<Loop
+			layout="none"
+			durationInFrames={Math.floor(fps * props.videoDuration)}
+		>
 			<Phone {...props} />
 		</Loop>
 	);

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,7 +1,9 @@
+import {staticFile} from 'remotion';
 import {getVideoMetadata} from '@remotion/media-utils';
 import {Composition} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {Scene, scenes} from './Scene';
+import {GLTFLoader} from 'three/examples/jsm/loaders/GLTFLoader';
 
 // Welcome to the Remotion Three Starter Kit!
 // Two compositions have been created, showing how to use

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,5 +1,7 @@
+import {getVideoMetadata} from '@remotion/media-utils';
 import {Composition} from 'remotion';
-import {Scene} from './Scene';
+import {NoReactInternals} from 'remotion/no-react';
+import {Scene, scenes} from './Scene';
 
 // Welcome to the Remotion Three Starter Kit!
 // Two compositions have been created, showing how to use
@@ -30,6 +32,28 @@ export const RemotionRoot: React.FC = () => {
 					deviceType: 'phone',
 					phoneColor: 'rgba(110, 152, 191, 0.00)' as const,
 					baseScale: 1,
+				}}
+				calculateMetadata={async ({props}) => {
+					const sources = scenes
+						.map((scene) => scene.objects.map((obj) => obj.videoSrc))
+						.flat(1)
+						.filter(NoReactInternals.truthy);
+
+					const durations = Object.fromEntries(
+						await Promise.all(
+							sources.map(async (source) => {
+								const {durationInSeconds} = await getVideoMetadata(source);
+								return [source, durationInSeconds] as const;
+							})
+						)
+					);
+
+					return {
+						props: {
+							...props,
+							durations,
+						},
+					};
 				}}
 			/>
 		</>

--- a/src/Scene.tsx
+++ b/src/Scene.tsx
@@ -1,7 +1,7 @@
-import {Series, random, staticFile} from 'remotion';
+import {Series, random, staticFile, delayRender} from 'remotion';
 import {getVideoMetadata, VideoMetadata} from '@remotion/media-utils';
 import {ThreeCanvas, useVideoTexture} from '@remotion/three';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useRef, useState, useSyncExternalStore} from 'react';
 import {AbsoluteFill, useVideoConfig, Video} from 'remotion';
 import {LoopedVideoPhone, Phone} from './Phone';
 import {z} from 'zod';
@@ -15,7 +15,7 @@ const container: React.CSSProperties = {
 
 const phoneVideo = staticFile('phone.mp4');
 
-const scenes = [
+export const scenes = [
 	{
 		objects: [
 			{
@@ -60,7 +60,7 @@ const scenes = [
 	},
 ];
 
-export const Scene: React.FC = () => {
+export const Scene: React.FC = (props: any) => {
 	const {width, height} = useVideoConfig();
 
 	return (
@@ -85,6 +85,7 @@ export const Scene: React.FC = () => {
 											aspectRatio={9 / 16}
 											videoSrc={obj.videoSrc!}
 											baseScale={1}
+											videoDuration={props.durations[obj.videoSrc!]}
 											position={obj.position}
 										/>
 									);


### PR DESCRIPTION
The previous solution did not work because of a weird behavior with R3F where each components `useState()` function got called multiple times (bug?).

This does not happen with normal React components but R3F uses a custom renderer.

There is a better way to do it anyway: Using calculateMetadata(), the duration only needs to be fetched once and we can remove the useEffect().